### PR TITLE
 Migrate CircleCI workflows to GitHub Actions (1/3)

### DIFF
--- a/.github/workflows/test-build-deploy.yml
+++ b/.github/workflows/test-build-deploy.yml
@@ -1,0 +1,31 @@
+name: ci
+on:
+  push:
+    branches: [master]
+    tags:
+      - v[0-9]+.[0-9]+.[0-9]+** # Tag filters not as strict due to different regex system on Github Actions
+  pull_request:
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    container:
+      image: quay.io/cortexproject/build-image:update-golang-1.14.9-eb0c8d4d2
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v1
+      - name: Sym Link Expected Path to Workspace
+        run: |
+          mkdir -p /go/src/github.com/cortexproject/cortex
+          ln -s $GITHUB_WORKSPACE/* /go/src/github.com/cortexproject/cortex
+      - name: Generate protobuf files
+        run: "protoc -I /go/src:./vendor/github.com/thanos-io/thanos/pkg:./vendor/github.com/gogo/protobuf:./vendor:./pkg/ruler --gogoslick_out=plugins=grpc,Mgoogle/protobuf/any.proto=github.com/gogo/protobuf/types,:./pkg/ruler ./pkg/ruler/ruler.proto"
+      - name: Lint
+        run: make BUILD_IN_CONTAINER=false lint
+      - name: Check Vendor Directory
+        run: make BUILD_IN_CONTAINER=false mod-check
+      - name: Check Protos
+        run: make BUILD_IN_CONTAINER=false check-protos
+      - name: Check Generated Documentation
+        run: make BUILD_IN_CONTAINER=false check-doc
+      - name: Check White Noise.
+        run: make BUILD_IN_CONTAINER=false check-white-noise

--- a/.github/workflows/test-build-deploy.yml
+++ b/.github/workflows/test-build-deploy.yml
@@ -29,3 +29,89 @@ jobs:
         run: make BUILD_IN_CONTAINER=false check-doc
       - name: Check White Noise.
         run: make BUILD_IN_CONTAINER=false check-white-noise
+
+  test:
+    runs-on: ubuntu-latest
+    container:
+      image: quay.io/cortexproject/build-image:update-golang-1.14.9-eb0c8d4d2
+    services:
+      cassandra:
+        image: cassandra:3.11
+        env:
+          JVM_OPTS: "-Xms1024M -Xmx1024M"
+        ports:
+        - 9042:9042
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v1
+      - name: Get Dependencies
+        run: go get -v -t -d ./...
+      - name: Sym Link Expected Path to Workspace
+        run: |
+          mkdir -p /go/src/github.com/cortexproject/cortex
+          ln -s $GITHUB_WORKSPACE/* /go/src/github.com/cortexproject/cortex
+      - name: Run Tests
+        run: CASSANDRA_TEST_ADDRESSES=cassandra:9042 make BUILD_IN_CONTAINER=false test
+
+  build:
+    runs-on: ubuntu-latest
+    container:
+      image: quay.io/cortexproject/build-image:update-golang-1.14.9-eb0c8d4d2
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v1
+      - name: Install Docker Client
+        run: |
+          set -x
+          VER="17.03.0-ce"
+          curl -L -o /tmp/docker-$VER.tgz https://download.docker.com/linux/static/stable/x86_64/docker-$VER.tgz
+          tar -xz -C /tmp -f /tmp/docker-$VER.tgz
+          mv /tmp/docker/* /usr/bin
+      - name: Sym Link Expected Path to Workspace
+        run: |
+          mkdir -p /go/src/github.com/cortexproject/cortex
+          ln -s $GITHUB_WORKSPACE/* /go/src/github.com/cortexproject/cortex
+      - name: Build Image
+        run: |
+          touch build-image/.uptodate
+          make BUILD_IN_CONTAINER=false
+      - name: Build Website
+        run: |
+          touch build-image/.uptodate
+          make BUILD_IN_CONTAINER=false web-build
+      - uses: actions/upload-artifact@v2
+        with:
+          name: website public
+          path: website/public/
+      - uses: actions/upload-artifact@v2
+        with:
+          name: Frontend Protobuf
+          path: pkg/querier/frontend/frontend.pb.go
+      - uses: actions/upload-artifact@v2
+        with:
+          name: Caching Index Client Protobuf
+          path: pkg/chunk/storage/caching_index_client.pb.go
+      - uses: actions/upload-artifact@v2
+        with:
+          name: Ring Protobuf
+          path: pkg/ring/ring.pb.go
+      - uses: actions/upload-artifact@v2
+        with:
+          name: Cortex Protobuf
+          path: pkg/ingester/client/cortex.pb.go
+      - uses: actions/upload-artifact@v2
+        with:
+          name: Rules Protobuf
+          path: pkg/ruler/rules/rules.pb.go
+      - name: Save Images
+        run: |
+          mkdir /tmp/images
+          ln -s /tmp/images ./docker-images
+          make BUILD_IN_CONTAINER=false save-images
+      - name: Zip Images
+        run: tar -zcvf images.tar.gz /tmp/images
+      - name: Upload Images Artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: Docker Images
+          path: ./images.tar.gz

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## master / unreleased
-
+* [CHANGE] Added GitHub Actions workflow equivalent to existing CircleCI one for migration purposes.
 * [CHANGE] Blocks storage: update the default HTTP configuration values for the S3 client to the upstream Thanos default values. #3244
   - `-blocks-storage.s3.http.idle-conn-timeout` is set 90 seconds.
   - `-blocks-storage.s3.http.response-header-timeout` is set to 2 minutes.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

### What this PR does

This is PR 1/3 of migrating Cortex's CI from CircleCI to GitHub Actions: 

**[Part 1/3](https://github.com/open-o11y/cortex/pull/6)** 👈 
* create `test-build-deploy` workflow under `.github/workflows`
* add readme
* adding the 3 base jobs
   * `lint`
   * `test`
   * `build`
* these jobs are run async and share no dependencies with each other
* workflow is run when a commit is pushed to `master` or when any PR is opened. However CD jobs will only run on the master branch and will be skipped otherwise
* all jobs in following PRs are dependant on one or more of these jobs finishing

**[Part 2/3](https://github.com/open-o11y/cortex/pull/7)** 
* adding jobs dependant on `build`
    * `integration`
    * `integration-config-db`
* This PR completes the CI portion of migration. The following PR will finish the remaining CD portion of the migration

**[Part 3/3](https://github.com/open-o11y/cortex/pull/8)** 
* This PR completes the migration from CircleCI to GitHub Actions
   * `deploy_website` is dependant on `build, test`
   * `deploy` is dependant on `build, test, lint, integration, integration-config-db`
* CD jobs will only run on the master branch and will be otherwise skipped



### Which issue(s) this PR fixes:
Fixes https://github.com/cortexproject/cortex/issues/3274

### Checklist
 - [ ] Tests updated <- Does not Apply to Workflow
- [x] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
