### PR TITLE
 Migrate CircleCI workflows to GitHub Actions (2/3)

### DIFF
--- a/.github/workflows-doc.md
+++ b/.github/workflows-doc.md
@@ -62,10 +62,6 @@ As of October 2020, GitHub Actions do not persist between different jobs in the 
 |-------------------------------|-----------|---------------------------------------------|-----------------------------|
 | website public                | build     | deploy_website                              | share data between jobs     |
 | Docker Images                 | build     | deploy, integration, integrations-config-db | share data between jobs     |
-| Frontend Protobuf             | build     |                                             | long term storage           |
-| Caching Index Client Protobuf | build     |                                             | long term storage           |
-| Ring Protobuf                 | build     |                                             | long term storage           |
-| Rules Protobuf                | build     |                                             | long term storage           |
 
 *Note:* Docker Images are zipped before uploading as a workaround. The images contain characters that are illegal in the upload-artifact action.
 ```yaml

--- a/.github/workflows/test-build-deploy.yml
+++ b/.github/workflows/test-build-deploy.yml
@@ -13,6 +13,8 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v2
+        # Commands in the Makefile are hardcoded with an assumed file structure of the CI container
+        # Symlink ensures paths specified in previous commands don’t break
       - name: Sym Link Expected Path to Workspace
         run: |
           mkdir -p /go/src/github.com/cortexproject/cortex
@@ -80,10 +82,97 @@ jobs:
           mkdir /tmp/images
           ln -s /tmp/images ./docker-images
           make BUILD_IN_CONTAINER=false save-images
-      - name: Zip Images
-        run: tar -zcvf images.tar.gz /tmp/images
-      - name: Upload Images Artifact
+      - name: Create Docker Images Archive
+        run: tar -cvf images.tar.gz /tmp/images
+      - name: Upload Docker Images Artifact
         uses: actions/upload-artifact@v2
         with:
           name: Docker Images
           path: ./images.tar.gz
+
+  integration:
+    needs: build
+    runs-on: ubuntu-16.04
+    steps:
+      - name: Install Docker Client
+        run: |
+          set -x
+          VER="17.03.0-ce"
+          curl -L -o /tmp/docker-$VER.tgz https://download.docker.com/linux/static/stable/x86_64/docker-$VER.tgz
+          tar -xz -C /tmp -f /tmp/docker-$VER.tgz
+          sudo mv /tmp/docker/* /usr/bin
+      - name: Upgrade golang
+        run: |
+          cd /tmp
+          wget https://dl.google.com/go/go1.14.9.linux-amd64.tar.gz
+          tar -zxvf go1.14.9.linux-amd64.tar.gz
+          sudo rm -fr /usr/local/go
+          sudo mv /tmp/go /usr/local/go
+          cd -
+      - name: Checkout Repo
+        uses: actions/checkout@v2
+      - name: Sym Link Expected Path to Workspace
+        run: |
+          sudo mkdir -p /go/src/github.com/cortexproject/cortex
+          sudo ln -s $GITHUB_WORKSPACE/* /go/src/github.com/cortexproject/cortex
+      - name: Download Docker Images Artifacts
+        uses: actions/download-artifact@v2
+        with:
+          name: Docker Images
+      - name: Create Docker Images Archive
+        run: tar -xvf images.tar.gz -C /
+      - name: Load Docker Images
+        run: |
+          ln -s /tmp/images ./docker-images
+          make BUILD_IN_CONTAINER=false load-images
+      - name: Preload Images
+        # We download docker images used by integration tests so that all images are available
+        # locally and the download time doesn't account in the test execution time, which is subject
+        # to a timeout
+        run: |
+          docker pull minio/minio:RELEASE.2019-12-30T05-45-39Z
+          docker pull amazon/dynamodb-local:1.11.477
+          docker pull consul:0.9
+          docker pull gcr.io/etcd-development/etcd:v3.4.7
+          docker pull quay.io/cortexproject/cortex:v0.6.0
+          docker pull quay.io/cortexproject/cortex:v0.7.0
+          docker pull quay.io/cortexproject/cortex:v1.0.0
+          docker pull quay.io/cortexproject/cortex:v1.1.0
+          docker pull shopify/bigtable-emulator:0.1.0
+          docker pull rinscy/cassandra:3.11.0
+          docker pull memcached:1.6.1
+          docker pull bouncestorage/swift-aio:55ba4331
+      - name: Integration Tests
+        run: |
+          export CORTEX_IMAGE_PREFIX="${IMAGE_PREFIX:-quay.io/cortexproject/}"
+          export CORTEX_IMAGE="${CORTEX_IMAGE_PREFIX}cortex:${TAG:-$(./tools/image-tag)}"
+          export CORTEX_CHECKOUT_DIR="/go/src/github.com/cortexproject/cortex"
+          echo "Running integration tests with image: $CORTEX_IMAGE"
+          go test -tags=requires_docker -timeout 1200s -v -count=1 ./integration/...
+        env:
+          IMAGE_PREFIX: ${{ secrets.IMAGE_PREFIX }}
+          TAG: ${{ github.event.push.tag_name }}
+  integration-configs-db:
+    needs: build
+    runs-on: ubuntu-16.04
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v2
+      - name: Install Docker Client
+        run: |
+          set -x
+          VER="17.03.0-ce"
+          curl -L -o /tmp/docker-$VER.tgz https://download.docker.com/linux/static/stable/x86_64/docker-$VER.tgz
+          tar -xz -C /tmp -f /tmp/docker-$VER.tgz
+          sudo mv /tmp/docker/* /usr/bin
+      - name: Download Docker Images Artifact
+        uses: actions/download-artifact@v2
+        with:
+          name: Docker Images
+      - name: Extract Docker Images Archive
+        run: tar -xvf images.tar.gz -C /
+      - name: Run Integration Configs Tests
+        run: |
+          touch build-image/.uptodate
+          MIGRATIONS_DIR=$(pwd)/cmd/cortex/migrations
+            make BUILD_IMAGE=quay.io/cortexproject/build-image:upgrade-build-image-debian-491e60715-WIP TTY='' configs-integration-test


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

### What this PR does

This is PR 2/3 of migrating Cortex's CI from CircleCI to GitHub Actions: 

**[Part 1/3](https://github.com/open-o11y/cortex/pull/6)** 
* create `test-build-deploy` workflow under `.github/workflows`
* add readme
* adding the 3 base jobs
   * `lint`
   * `test`
   * `build`
* these jobs are run async and share no dependencies with each other
* workflow is run when a commit is pushed to `master` or when any PR is opened. However CD jobs will only run on the master branch and will be skipped otherwise
* all jobs in following PRs are dependant on one or more of these jobs finishing

**[Part 2/3](https://github.com/open-o11y/cortex/pull/7)**  👈 
* adding jobs dependant on `build`
    * `integration`
    * `integration-config-db`
* This PR completes the CI portion of migration. The following PR will finish the remaining CD portion of the migration

**[Part 3/3](https://github.com/open-o11y/cortex/pull/8)** 
* This PR completes the migration from CircleCI to GitHub Actions
   * `deploy_website` is dependant on `build, test`
   * `deploy` is dependant on `build, test, lint, integration, integration-config-db`
* CD jobs will only run on the master branch and will be otherwise skipped



### Which issue(s) this PR fixes:
fixes https://github.com/cortexproject/cortex/issues/3274

### Checklist
 - [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
